### PR TITLE
feat: rename "addons" folder into "hooks"

### DIFF
--- a/client/hooks/AddonAdditionalField/MeinBerlinAdditionalField.vue
+++ b/client/hooks/AddonAdditionalField/MeinBerlinAdditionalField.vue
@@ -11,7 +11,7 @@
     v-model="currentValue"
     pattern="^.*\S-\S.*$"
     @blur="$emit('addonEvent:emit', { name: 'blur', payload: addonPayload })"
-    @focus="handleFocus"/>
+    @focus="handleFocus" />
 
   <dp-select
     v-else
@@ -23,14 +23,14 @@
     }"
     :options="options"
     v-model="currentValue"
-    @select="$emit('addonEvent:emit', { name: 'selected', payload: addonPayload })"/>
+    @select="$emit('addonEvent:emit', { name: 'selected', payload: addonPayload })" />
 </template>
 
 <script>
 import { dpApi, DpInput, DpSelect } from '@demos-europe/demosplan-ui'
 
 export default {
-  name: 'AddonAdditionalField',
+  name: 'MeinBerlinAdditionalField',
 
   components: {
     DpInput,
@@ -75,7 +75,7 @@ export default {
     }
   },
 
-  data() {
+  data () {
     return {
       currentValue: '',
       initValue: '',
@@ -115,7 +115,7 @@ export default {
 
   computed: {
     addonPayload () {
-      let attributes = {}
+      const attributes = {}
 
       if (this.attribute) {
         attributes[this.attribute] = this.currentValue

--- a/demosplan-addon.yml
+++ b/demosplan-addon.yml
@@ -9,4 +9,4 @@ demosplan_addon:
     manifest: dist/assets-manifest.json
     hooks:
      addon.additional.field:
-        entry: AddonAdditionalField
+        entry: MeinBerlinAdditionalField

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,9 +3,9 @@ const DemosPlanAddon = require('@demos-europe/demosplan-addon-client-builder')
 const config = DemosPlanAddon.build(
   'demosplan-addon-mein-berlin',
   {
-    AddonAdditionalField: DemosPlanAddon.resolve(
-      'client/addons/MeinBerlinAdditionalField.vue'
-    ),
+    MeinBerlinAdditionalField: DemosPlanAddon.resolve(
+      'client/hooks/AddonAdditionalField/MeinBerlinAdditionalField.vue'
+    )
   }
 )
 


### PR DESCRIPTION
To fix a bug with Tailwind 4 not being able to resolve a child folder named the same as a parent folder within a glob expression, this change is needed.

To also better communicate which files are used in which hook, the subsequent folders are renamed to match the (upper camel) hook name.