### PR TITLE
Add ADO sync workflow

### DIFF
--- a/.github/workflows/ado_sync.yml
+++ b/.github/workflows/ado_sync.yml
@@ -1,0 +1,17 @@
+name: Sync with ADO
+
+on:
+  push:
+    branches:
+      - main
+      - release
+
+
+jobs:
+  sync:
+    uses: demos-europe/demosplan-workflows/.github/workflows/ado_sync_ssh.yml@main
+    secrets:
+      ADO_TOKEN: ${{ secrets.ADO_SSH_KEY }}
+    with:
+      ADO_REPO_URL: "ssh://www.dev.diplanung.de:22/DefaultCollection/DiPlanBeteiligung/_git/diplanbeteiligung-addon-mein-berlin"
+      BRANCH_NAME: ${{ github.ref == 'refs/heads/main' && format('feature/main-sync/{0}', github.run_id) || github.ref == 'refs/heads/release' && 'release' || 'other' }}


### PR DESCRIPTION
  Adds a GitHub Actions workflow that mirrors pushes to ADO on the main and release branches
                                                                                                                                   
  - main pushes sync to a new feature/main-sync/{run_id} branch in ADO                                                             
  - release pushes sync directly to the release branch in ADO
  - Uses the shared demos-europe/demosplan-workflows reusable workflow with SSH key auth   