### PR TITLE
feat(refs DPLAN-16766): replace legacy phase string APIs with ProcedurePhaseDefinition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # CHANGELOG
 
 ## UNRELEASED
+**Integrate ProcedurePhaseDefinition into MeinBerlin communication (DPLAN-16766)**
+- Replace `getExternalPhaseKeys()`/`getPublicParticipationPhase()` with `getPublicParticipationPhasePermissionset()` in `MeinBerlinAddonRelationService`
+- Replace `getPhaseNameWithPriorityExternal()` with `getPhaseDefinition()->getName()` for phase name resolution
+- `RelevelantProcedurePhasePropertiesForMeinBerlinCommunication` now uses `phaseDefinition` instead of `name`
+- `MeinBerlinUpdateProcedureService` resolves a `ProcedurePhaseDefinitionInterface` instance in the public-phase change set to its name before sending the update to MeinBerlin
+- Remove `GlobalConfigInterface` dependency from `RssFeedController`
+
 ## v0.29 (2026-05-20)
 - **chore DPLAN-17129**: Align composer dependencies with core's Doctrine ORM v3 upgrade
     - Widen `demos-europe/demosplan-addon` constraint from `~v0.67` to `^0.71`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## UNRELEASED
 - **fix BEAA2-39**: Support multiple orgs sharing the same meinBerlin organisation ID in RSS feed
 
+**Replace legacy phase string APIs with ProcedurePhaseDefinition (DPLAN-16766)**
+- Replace `getExternalPhaseKeys()`/`getPublicParticipationPhase()` with `getPublicParticipationPhasePermissionset()` in `MeinBerlinAddonRelationService`
+- Replace `getPhaseNameWithPriorityExternal()` with `getPhaseDefinition()->getName()` for phase name resolution
+- Update `RelevelantProcedurePhasePropertiesForMeinBerlinCommunication` to use `phaseDefinition` instead of `name`
+- Remove `GlobalConfigInterface` dependency from `RssFeedController`
+
 ## v0.27 (2026-02-27)
 - save meinBerlin response in log prior to payload to avoid stripping the response
 - **BEAA2-40**: Truncate tile_image base64 in error logs to reduce log size

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## UNRELEASED
+## v0.29-rc1 (2026-04-29)
 - **fix BEAA2-39**: Support multiple orgs sharing the same meinBerlin organisation ID in RSS feed
 
 **Replace legacy phase string APIs with ProcedurePhaseDefinition (DPLAN-16766)**

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "php": "^8.1",
     "symfony/translation": "6.*.*",
     "demos-europe/demosplan-addon-installer": "^0",
-    "demos-europe/demosplan-addon": "dev-f-DPLAN-16766-phase-definition-interface-integration",
+    "demos-europe/demosplan-addon": "~v0.72",
     "doctrine/doctrine-bundle": "^2",
     "doctrine/doctrine-migrations-bundle": "^3.2",
     "doctrine/orm": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,12 @@
       "DemosEurope\\DemosplanAddon\\DemosMeinBerlin\\Tests\\": "tests/"
     }
   },
-  "minimum-stability": "dev",
-  "prefer-stable": true,
+  "minimum-stability": "stable",
   "require": {
     "php": "^8.1",
     "symfony/translation": "6.*.*",
     "demos-europe/demosplan-addon-installer": "^0",
-    "demos-europe/demosplan-addon": "dev-f-DPLAN-16766-phase-definition-interface-integration@dev",
+    "demos-europe/demosplan-addon": "dev-f-DPLAN-16766-phase-definition-interface-integration",
     "doctrine/doctrine-bundle": "^2",
     "doctrine/doctrine-migrations-bundle": "^3.2",
     "gedmo/doctrine-extensions": "^3",

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,13 @@
       "DemosEurope\\DemosplanAddon\\DemosMeinBerlin\\Tests\\": "tests/"
     }
   },
-  "minimum-stability": "stable",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
   "require": {
     "php": "^8.1",
     "symfony/translation": "6.*.*",
     "demos-europe/demosplan-addon-installer": "^0",
-    "demos-europe/demosplan-addon": "~v0.67",
+    "demos-europe/demosplan-addon": "dev-f-DPLAN-16766-phase-definition-interface-integration@dev",
     "doctrine/doctrine-bundle": "^2",
     "doctrine/doctrine-migrations-bundle": "^3.2",
     "gedmo/doctrine-extensions": "^3",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "demos-europe/demosplan-addon-mein-berlin",
   "description": "demosplan Addon to integrate with mein.berlin.de",
-  "version": "v0.27",
+  "version": "v0.29-rc1",
   "type": "demosplan-addon",
   "license": "proprietary",
   "autoload": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "demosplan-addon-mein-berlin",
-  "version": "v0.27",
+  "version": "v0.29-rc1",
   "description": "UI for DemosMeinBerlin demosplan-core addon",
   "repository": "git@github.com:demos-europe/demosplan-addon-mein-berlin",
   "license": "LicenseRef-LICENSE",

--- a/src/Controller/RssFeedController.php
+++ b/src/Controller/RssFeedController.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace DemosEurope\DemosplanAddon\DemosMeinBerlin\Controller;
 
-use DemosEurope\DemosplanAddon\Contracts\Config\GlobalConfigInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
 use DemosEurope\DemosplanAddon\DemosMeinBerlin\Repository\MeinBerlinAddonOrgaRelationRepository;
 use DemosEurope\DemosplanAddon\DemosMeinBerlin\Service\MeinBerlinAddonRelationService;
@@ -29,7 +28,6 @@ use DateTime;
 class RssFeedController extends AbstractController
 {
     public function __construct(
-        protected readonly GlobalConfigInterface $demosplanConfig,
         private readonly RouterInterface $router,
         protected readonly TranslatorInterface $translator,
         private readonly LoggerInterface $logger,
@@ -53,8 +51,6 @@ class RssFeedController extends AbstractController
             return new Response('', 200);
         }
 
-        $externalPhaseKeys = $this->demosplanConfig->getExternalPhaseKeys('read||write');
-
         // Aggregate procedures from all organizations sharing this meinBerlinId
         $proceduresByOrga = [];
         $feedOrgaNames = [];
@@ -63,7 +59,7 @@ class RssFeedController extends AbstractController
             if (null === $orga) {
                 continue;
             }
-            $visibleProcedures = $orgaRelationService->getVisibleProcedures($externalPhaseKeys, $orga);
+            $visibleProcedures = $orgaRelationService->getVisibleProcedures($orga);
             if ([] !== $visibleProcedures) {
                 $feedOrgaNames[] = $orga->getName();
             }
@@ -116,9 +112,7 @@ class RssFeedController extends AbstractController
         $endDate = $procedure->getPublicParticipationEndDate()->format('d.m.Y');
         $descParts = [];
         $descParts[] = "{$startDate} - {$endDate}";
-        $descParts[] = $this->demosplanConfig->getPhaseNameWithPriorityExternal(
-            $procedure->getPublicParticipationPhase()
-        );
+        $descParts[] = $procedure->getPublicParticipationPhaseObject()->getPhaseDefinition()->getName();
         if ('' !== $procedure->getExternalDesc()) {
             $descParts[] = $procedure->getExternalDesc();
         }

--- a/src/Enum/RelevelantProcedurePhasePropertiesForMeinBerlinCommunication.php
+++ b/src/Enum/RelevelantProcedurePhasePropertiesForMeinBerlinCommunication.php
@@ -17,5 +17,5 @@ enum RelevelantProcedurePhasePropertiesForMeinBerlinCommunication: string
 
     case start_date = 'startDate';
     case end_date = 'endDate';
-    case status = 'name';
+    case status = 'phaseDefinition';
 }

--- a/src/Logic/MeinBerlinCreateProcedureService.php
+++ b/src/Logic/MeinBerlinCreateProcedureService.php
@@ -103,7 +103,7 @@ class MeinBerlinCreateProcedureService
             RelevelantProcedurePhasePropertiesForMeinBerlinCommunication::end_date->name =>
                 $procedure->getPublicParticipationPhaseObject()->getEndDate()->format('Y-m-d\TH:i'),
             RelevelantProcedurePhasePropertiesForMeinBerlinCommunication::status->name =>
-                $procedure->getPublicParticipationPhaseObject()->getName(),
+                $procedure->getPublicParticipationPhaseObject()->getPhaseDefinition()->getName(),
             RelevantProcedureSettingsPropertiesForMeinBerlinCommunication::tile_image->name =>
                 $this->getBase64PictogramFileString($procedure),
             RelevantProcedureSettingsPropertiesForMeinBerlinCommunication::point->name =>

--- a/src/Logic/MeinBerlinUpdateProcedureService.php
+++ b/src/Logic/MeinBerlinUpdateProcedureService.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\DemosMeinBerlin\Logic;
 
 use DateTime;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedurePhaseDefinitionInterface;
 use DemosEurope\DemosplanAddon\Contracts\MessageBagInterface;
 use DemosEurope\DemosplanAddon\DemosMeinBerlin\Entity\MeinBerlinAddonEntity;
 use DemosEurope\DemosplanAddon\DemosMeinBerlin\Enum\RelevantProcedureCurrentSlugPropertiesForMeinBerlinCommunication;
@@ -369,6 +370,20 @@ class MeinBerlinUpdateProcedureService
     }
 
     /**
+     * @param array<string, mixed> $phaseChanges
+     * @return array<string, mixed>
+     */
+    private function resolvePhaseDefinitionToName(array $phaseChanges): array
+    {
+        $key = RelevelantProcedurePhasePropertiesForMeinBerlinCommunication::status->value;
+        if (array_key_exists($key, $phaseChanges) && $phaseChanges[$key] instanceof ProcedurePhaseDefinitionInterface) {
+            $phaseChanges[$key] = $phaseChanges[$key]->getName();
+        }
+
+        return $phaseChanges;
+    }
+
+    /**
      * @param array<string, mixed> $relevantProcedurePublicPhaseChanges
      * @return array<string, mixed>
      */
@@ -397,6 +412,7 @@ class MeinBerlinUpdateProcedureService
             $relevantProcedurePublicPhaseChanges
         );
         $relevantProcedurePublicPhaseChanges = $this->formatDateTime($relevantProcedurePublicPhaseChanges);
+        $relevantProcedurePublicPhaseChanges = $this->resolvePhaseDefinitionToName($relevantProcedurePublicPhaseChanges);
 
         // map our property names to their requested names
         return RelevelantProcedurePhasePropertiesForMeinBerlinCommunication::

--- a/src/Service/MeinBerlinAddonRelationService.php
+++ b/src/Service/MeinBerlinAddonRelationService.php
@@ -18,16 +18,18 @@ use Exception;
 class MeinBerlinAddonRelationService
 {
     /**
-     * @param array<int, string> $phaseKeys
      * @return ProcedureInterface[]
      * @throws Exception
      */
-    public function getVisibleProcedures(array $phaseKeys, OrgaInterface $orga): array
+    public function getVisibleProcedures(OrgaInterface $orga): array
     {
         $procedures = $orga->getProcedures();
-        $phaseKeysCollection = collect($phaseKeys);
         $hits = collect($procedures)->filter(
-            static fn (ProcedureInterface $procedure): bool => $phaseKeysCollection->contains($procedure->getPublicParticipationPhase())
+            static fn (ProcedureInterface $procedure): bool => in_array(
+                $procedure->getPublicParticipationPhasePermissionset(),
+                ['read', 'write'],
+                true
+            )
         )
         ->sortByDesc(static fn (ProcedureInterface $procedure): int => $procedure->getPublicParticipationEndDateTimestamp());
 

--- a/src/Service/MeinBerlinAddonRelationService.php
+++ b/src/Service/MeinBerlinAddonRelationService.php
@@ -27,7 +27,7 @@ class MeinBerlinAddonRelationService
         $hits = collect($procedures)->filter(
             static fn (ProcedureInterface $procedure): bool => in_array(
                 $procedure->getPublicParticipationPhasePermissionset(),
-                ['read', 'write'],
+                [ProcedureInterface::PROCEDURE_PHASE_PERMISSIONSET_READ, ProcedureInterface::PROCEDURE_PHASE_PERMISSIONSET_WRITE],
                 true
             )
         )

--- a/tests/MeinBerlinAddonRelationServiceTest.php
+++ b/tests/MeinBerlinAddonRelationServiceTest.php
@@ -20,11 +20,11 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
 
     public function testReturnsOnlyProceduresInAllowedPhases(): void
     {
-        $visible = $this->createProcedureMock('p-1', 'participation', 1000);
-        $hidden = $this->createProcedureMock('p-2', 'configuration', 2000);
+        $visible = $this->createProcedureMock('p-1', 'read', 1000);
+        $hidden = $this->createProcedureMock('p-2', 'preparation', 2000);
         $orga = $this->createOrgaMock([$visible, $hidden]);
 
-        $result = $this->sut->getVisibleProcedures(['participation'], $orga);
+        $result = $this->sut->getVisibleProcedures($orga);
 
         self::assertCount(1, $result);
         self::assertSame('p-1', array_values($result)[0]->getId());
@@ -32,22 +32,22 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
 
     public function testReturnsEmptyArrayWhenNoProceduresMatchPhase(): void
     {
-        $procedure = $this->createProcedureMock('p-1', 'configuration', 1000);
+        $procedure = $this->createProcedureMock('p-1', 'preparation', 1000);
         $orga = $this->createOrgaMock([$procedure]);
 
-        $result = $this->sut->getVisibleProcedures(['participation'], $orga);
+        $result = $this->sut->getVisibleProcedures($orga);
 
         self::assertSame([], $result);
     }
 
     public function testSortsProceduresByEndDateDescending(): void
     {
-        $oldest = $this->createProcedureMock('p-oldest', 'participation', 1000);
-        $middle = $this->createProcedureMock('p-middle', 'participation', 2000);
-        $newest = $this->createProcedureMock('p-newest', 'participation', 3000);
+        $oldest = $this->createProcedureMock('p-oldest', 'read', 1000);
+        $middle = $this->createProcedureMock('p-middle', 'read', 2000);
+        $newest = $this->createProcedureMock('p-newest', 'read', 3000);
         $orga = $this->createOrgaMock([$oldest, $middle, $newest]);
 
-        $result = array_values($this->sut->getVisibleProcedures(['participation'], $orga));
+        $result = array_values($this->sut->getVisibleProcedures($orga));
 
         self::assertSame('p-newest', $result[0]->getId());
         self::assertSame('p-middle', $result[1]->getId());
@@ -58,17 +58,17 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     {
         $orga = $this->createOrgaMock([]);
 
-        self::assertSame([], $this->sut->getVisibleProcedures(['participation'], $orga));
+        self::assertSame([], $this->sut->getVisibleProcedures($orga));
     }
 
-    public function testMultiplePhaseKeysAreRespected(): void
+    public function testBothReadAndWritePermissionSetsAreVisible(): void
     {
-        $procA = $this->createProcedureMock('p-1', 'participation', 1000);
-        $procB = $this->createProcedureMock('p-2', 'evaluating', 2000);
-        $procC = $this->createProcedureMock('p-3', 'configuration', 3000);
-        $orga = $this->createOrgaMock([$procA, $procB, $procC]);
+        $procRead = $this->createProcedureMock('p-1', 'read', 1000);
+        $procWrite = $this->createProcedureMock('p-2', 'write', 2000);
+        $procHidden = $this->createProcedureMock('p-3', 'preparation', 3000);
+        $orga = $this->createOrgaMock([$procRead, $procWrite, $procHidden]);
 
-        $result = $this->sut->getVisibleProcedures(['participation', 'evaluating'], $orga);
+        $result = $this->sut->getVisibleProcedures($orga);
 
         self::assertCount(2, $result);
     }
@@ -80,14 +80,14 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     public function testMultiOrgAggregationCollectsProceduresFromAllOrgs(): void
     {
         $orgaA = $this->createOrgaMock([
-            $this->createProcedureMock('p-a1', 'participation', 3000),
+            $this->createProcedureMock('p-a1', 'read', 3000),
         ]);
         $orgaB = $this->createOrgaMock([
-            $this->createProcedureMock('p-b1', 'participation', 2000),
-            $this->createProcedureMock('p-b2', 'participation', 1000),
+            $this->createProcedureMock('p-b1', 'read', 2000),
+            $this->createProcedureMock('p-b2', 'read', 1000),
         ]);
 
-        $procedures = $this->aggregateVisibleProcedures(['participation'], [$orgaA, $orgaB]);
+        $procedures = $this->aggregateVisibleProcedures([$orgaA, $orgaB]);
 
         self::assertCount(3, $procedures);
         self::assertSame('p-a1', $procedures[0]->getId());
@@ -98,23 +98,22 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     /**
      * Real-world scenario: multiple orgs share the same external ID,
      * but only one has procedures in a visible phase. Others are either
-     * empty or only have procedures in non-visible phases like 'configuration'.
+     * empty or only have procedures in non-visible phases.
      */
     public function testMultiOrgAggregationWithMixedVisibility(): void
     {
         $orgaWithVisible = $this->createOrgaMock([
-            $this->createProcedureMock('p-1', 'participation', 2000),
+            $this->createProcedureMock('p-1', 'read', 2000),
         ], 'Org A');
         $orgaAllHidden = $this->createOrgaMock([
-            $this->createProcedureMock('p-2', 'configuration', 3000),
+            $this->createProcedureMock('p-2', 'preparation', 3000),
         ], 'Org B');
         $orgaEmpty = $this->createOrgaMock([], 'Org C');
 
         $orgas = [$orgaWithVisible, $orgaAllHidden, $orgaEmpty];
-        $phaseKeys = ['participation', 'evaluating'];
 
-        $procedures = $this->aggregateVisibleProcedures($phaseKeys, $orgas);
-        $orgaNames = $this->collectOrgaNamesWithVisibleProcedures($phaseKeys, $orgas);
+        $procedures = $this->aggregateVisibleProcedures($orgas);
+        $orgaNames = $this->collectOrgaNamesWithVisibleProcedures($orgas);
 
         self::assertCount(1, $procedures);
         self::assertSame('p-1', $procedures[0]->getId());
@@ -129,21 +128,20 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     public function testMultiOrgAggregationShowsAllContributingOrgNames(): void
     {
         $orgaA = $this->createOrgaMock([
-            $this->createProcedureMock('p-a1', 'participation', 3000),
-            $this->createProcedureMock('p-a2', 'evaluating', 1000),
+            $this->createProcedureMock('p-a1', 'read', 3000),
+            $this->createProcedureMock('p-a2', 'write', 1000),
         ], 'Org A');
         $orgaB = $this->createOrgaMock([
-            $this->createProcedureMock('p-b1', 'participation', 2000),
+            $this->createProcedureMock('p-b1', 'read', 2000),
         ], 'Org B');
         $orgaNonContributing = $this->createOrgaMock([
-            $this->createProcedureMock('p-c1', 'configuration', 4000),
+            $this->createProcedureMock('p-c1', 'preparation', 4000),
         ], 'Org C');
 
         $orgas = [$orgaA, $orgaB, $orgaNonContributing];
-        $phaseKeys = ['participation', 'evaluating'];
 
-        $procedures = $this->aggregateVisibleProcedures($phaseKeys, $orgas);
-        $orgaNames = $this->collectOrgaNamesWithVisibleProcedures($phaseKeys, $orgas);
+        $procedures = $this->aggregateVisibleProcedures($orgas);
+        $orgaNames = $this->collectOrgaNamesWithVisibleProcedures($orgas);
 
         self::assertCount(3, $procedures);
         self::assertSame('Org A, Org B', implode(', ', $orgaNames));
@@ -152,16 +150,14 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     /**
      * Replicates the aggregation logic from RssFeedController::generateRssFeed.
      *
-     * @param string[]        $phaseKeys
      * @param OrgaInterface[] $orgas
-     *
      * @return ProcedureInterface[]
      */
-    private function aggregateVisibleProcedures(array $phaseKeys, array $orgas): array
+    private function aggregateVisibleProcedures(array $orgas): array
     {
         $proceduresByOrga = [];
         foreach ($orgas as $orga) {
-            $proceduresByOrga[] = $this->sut->getVisibleProcedures($phaseKeys, $orga);
+            $proceduresByOrga[] = $this->sut->getVisibleProcedures($orga);
         }
 
         $procedures = array_merge(...$proceduresByOrga);
@@ -175,16 +171,14 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
     /**
      * Replicates the org name collection from RssFeedController::generateRssFeed.
      *
-     * @param string[]        $phaseKeys
      * @param OrgaInterface[] $orgas
-     *
      * @return string[]
      */
-    private function collectOrgaNamesWithVisibleProcedures(array $phaseKeys, array $orgas): array
+    private function collectOrgaNamesWithVisibleProcedures(array $orgas): array
     {
         $names = [];
         foreach ($orgas as $orga) {
-            $visibleProcedures = $this->sut->getVisibleProcedures($phaseKeys, $orga);
+            $visibleProcedures = $this->sut->getVisibleProcedures($orga);
             if ([] !== $visibleProcedures) {
                 $names[] = $orga->getName();
             }
@@ -193,11 +187,11 @@ class MeinBerlinAddonRelationServiceTest extends TestCase
         return $names;
     }
 
-    private function createProcedureMock(string $id, string $phase, int $endTimestamp): ProcedureInterface
+    private function createProcedureMock(string $id, string $permissionset, int $endTimestamp): ProcedureInterface
     {
         $procedure = $this->createMock(ProcedureInterface::class);
         $procedure->method('getId')->willReturn($id);
-        $procedure->method('getPublicParticipationPhase')->willReturn($phase);
+        $procedure->method('getPublicParticipationPhasePermissionset')->willReturn($permissionset);
         $procedure->method('getPublicParticipationEndDateTimestamp')->willReturn($endTimestamp);
 
         return $procedure;

--- a/tests/MeinBerlinCreateProcedureServiceTest.php
+++ b/tests/MeinBerlinCreateProcedureServiceTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace DemosEurope\DemosplanAddon\DemosMeinBerlin\Tests;
 
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureInterface;
+use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedurePhaseDefinitionInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedurePhaseInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\ProcedureSettingsInterface;
 use DemosEurope\DemosplanAddon\Contracts\Entities\SlugInterface;
@@ -58,10 +59,13 @@ class MeinBerlinCreateProcedureServiceTest extends TestCase
         $procedureSettings->method('getPictogramAltText')->willReturn('altText');
         $this->procedure->method('getSettings')->willReturn($procedureSettings);
 
+        $phaseDefinition = $this->createMock(ProcedurePhaseDefinitionInterface::class);
+        $phaseDefinition->method('getName')->willReturn('phaseName');
+
         $publicParticipationPhase = $this->createMock(ProcedurePhaseInterface::class);
         $publicParticipationPhase->method('getStartDate')->willReturn(new \DateTime('2024-11-14'));
         $publicParticipationPhase->method('getEndDate')->willReturn(new \DateTime('2099-12-31'));
-        $publicParticipationPhase->method('getName')->willReturn('phaseName');
+        $publicParticipationPhase->method('getPhaseDefinition')->willReturn($phaseDefinition);
         $this->procedure->method('getPublicParticipationPhaseObject')->willReturn($publicParticipationPhase);
 
         $currentSlug = $this->createMock(SlugInterface::class);


### PR DESCRIPTION
Ticket: [DPLAN-16766](https://demoseurope.youtrack.cloud/issue/DPLAN-16766)

## Summary
- Remove `GlobalConfigInterface` dependency from `RssFeedController`; replace `getExternalPhaseKeys()` + `getPublicParticipationPhase()` filter with `getPublicParticipationPhasePermissionset()` in `MeinBerlinAddonRelationService`
- Replace `getPhaseNameWithPriorityExternal()` call with `getPublicParticipationPhaseObject()->getPhaseDefinition()->getName()`
- Fix `MeinBerlinCreateProcedureService` to call `getPhaseDefinition()->getName()` instead of the removed `getName()`
- Correct `RelevelantProcedurePhasePropertiesForMeinBerlinCommunication::status` from `'name'` to `'phaseDefinition'` to match the actual PHP property name in `ProcedurePhase` (used by the reflection-based changeset detector)
- Add `resolvePhaseDefinitionToName()` in `MeinBerlinUpdateProcedureService` to unwrap `ProcedurePhaseDefinitionInterface` objects in the update changeset before sending to Mein Berlin

## Changes
- `src/Controller/RssFeedController.php` — drop `GlobalConfigInterface`, update `getVisibleProcedures` call, replace phase name lookup
- `src/Service/MeinBerlinAddonRelationService.php` — remove `$phaseKeys` param, filter by permissionset directly
- `src/Logic/MeinBerlinCreateProcedureService.php` — `->getName()` → `->getPhaseDefinition()->getName()`
- `src/Enum/RelevelantProcedurePhasePropertiesForMeinBerlinCommunication.php` — `status = 'phaseDefinition'`
- `src/Logic/MeinBerlinUpdateProcedureService.php` — add `resolvePhaseDefinitionToName()` step in phase change mapping