### PR TITLE
fix: distinguish config errors from response-parse errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## UNRELEASED
+- **fix**: distinguish missing-config errors from response-parse errors in procedure create/update logging
+
 ## v0.28 (2026-04-13)
 - **fix BEAA2-39**: Support multiple orgs sharing the same meinBerlin organisation ID in RSS feed
 

--- a/src/Logic/MeinBerlinProcedureCommunicator.php
+++ b/src/Logic/MeinBerlinProcedureCommunicator.php
@@ -51,6 +51,8 @@ class MeinBerlinProcedureCommunicator
         string $bplanId,
         string $procedureId
     ): void {
+        $headers = $this->resolveMeinBerlinHeader($preparedProcedureData, null, $procedureId);
+
         try {
             $method = 'PATCH';
             $url = str_replace(
@@ -63,7 +65,7 @@ class MeinBerlinProcedureCommunicator
                 $method,
                 $url,
                 [
-                    'headers' => $this->getMeinBerlinHeader(),
+                    'headers' => $headers,
                     'json' => $preparedProcedureData
                 ]
             );
@@ -139,6 +141,8 @@ class MeinBerlinProcedureCommunicator
         string $organisationId,
         bool $flushIsInQueued
     ): void {
+        $headers = $this->resolveMeinBerlinHeader($preparedProcedureData, $correspondingAddonEntity);
+
         try {
             $method = 'POST';
             $url = str_replace(
@@ -152,7 +156,7 @@ class MeinBerlinProcedureCommunicator
                 $method,
                 $url,
                 [
-                    'headers' => $this->getMeinBerlinHeader(),
+                    'headers' => $headers,
                     'json' => $preparedProcedureData
                 ]
             );
@@ -226,8 +230,7 @@ class MeinBerlinProcedureCommunicator
             throw new MeinBerlinCommunicationException($e->getMessage());
         } catch (InvalidArgumentException $e) {
             $this->logger->error(
-                'demosplan-mein-berlin-addon failed to parse the responseContent.
-                 Expected different type or layout',
+                'demosplan-mein-berlin-addon got an unexpected response body shape during create (parse/assert failure)',
                 [
                     'Exception' => $e,
                     'ExceptionMessage' => $e->getMessage(),
@@ -266,6 +269,35 @@ class MeinBerlinProcedureCommunicator
             'Content-Type' => 'application/json',
             'Authorization' => $bearerAuth
         ];
+    }
+
+    /**
+     * @param array<string, string|bool> $preparedProcedureData
+     * @return array{Accept: 'application/json', Content-Type: 'application/json', Authorization: non-empty-string}
+     * @throws MeinBerlinCommunicationException
+     */
+    private function resolveMeinBerlinHeader(
+        array $preparedProcedureData,
+        ?MeinBerlinAddonEntity $correspondingAddonEntity = null,
+        ?string $procedureId = null
+    ): array {
+        try {
+            return $this->getMeinBerlinHeader();
+        } catch (ParameterNotFoundException | InvalidArgumentException $e) {
+            $this->logger->error(
+                'demosplan-mein-berlin-addon: invalid configuration (mein_berlin_authorization missing or empty)',
+                [
+                    'Exception' => $e,
+                    'ExceptionMessage' => $e->getMessage(),
+                    'procedureId' => $procedureId
+                        ?? $correspondingAddonEntity?->getProcedure()?->getId(),
+                    'payload' => $this->truncateTileImageForLogging($preparedProcedureData),
+                ]
+            );
+            throw new MeinBerlinCommunicationException(
+                'Invalid mein_berlin configuration: '.$e->getMessage()
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- An empty `mein_berlin_authorization` parameter caused `getMeinBerlinHeader()` to throw a Webmozart `InvalidArgumentException` inside the request-building try block, which was caught and logged as *"failed to parse the responseContent. Expected different type or layout"* — blaming the API response for a local configuration problem.
- Hoist header resolution into a dedicated `resolveMeinBerlinHeader()` wrapper that catches `ParameterNotFoundException | InvalidArgumentException` and logs *"invalid configuration (mein_berlin_authorization missing or empty)"*.
- Reword the remaining `InvalidArgumentException` catch in `createProcedure` to accurately describe a response-shape/parse failure.

Applied in both `createProcedure` and `updateProcedure`.

## Test plan
- [ ] Trigger a procedure create with `MEIN_BERLIN_AUTHORIZATION` unset → log shows the config-specific message, not the misleading response-parse message.
- [ ] With valid auth, confirm a malformed response payload (missing `id`) still produces the new "unexpected response body shape" log line.
- [ ] Verify normal create/update flows still succeed end-to-end.