### PR TITLE
fix(refs DPLAN-17776): limit procedure pictogram alt text to 79 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## UNRELEASED
+- **fix DPLAN-17776**: Limit the procedure pictogram alt text input to 79 characters, since mein.berlin.de rejects alt text of 80 or more characters
+
 ## v0.30 (2026-05-26)
 **Integrate ProcedurePhaseDefinition into MeinBerlin communication (DPLAN-16766)**
 - Replace `getExternalPhaseKeys()`/`getPublicParticipationPhase()` with `getPublicParticipationPhasePermissionset()` in `MeinBerlinAddonRelationService`

--- a/client/hooks/InterfaceFieldsToTransmit/MeinBerlinProcedurePictogram.vue
+++ b/client/hooks/InterfaceFieldsToTransmit/MeinBerlinProcedurePictogram.vue
@@ -88,6 +88,7 @@
         text: Translator.trans('procedure.pictogram.altText'),
         tooltip: Translator.trans('procedure.pictogram.altText.toolTipp')
       }"
+      :maxlength="79"
       :readonly="!hasBerlinOrgaId"
       class="my-2"
       data-cy="procedure:pictogramAltText"


### PR DESCRIPTION
## Summary [DPLAN-17776](https://demoseurope.youtrack.cloud/issue/DPLAN-17776/ADO-Issue-54886-Mitte-Verfahren-wird-nicht-an-mein.berlin.de-ubermittelt)

mein.berlin.de rejects a procedure pictogram alt text of 80 or more characters, which caused the procedure transfer to fail with only a generic error after the settings had already been saved.

This caps the "Alternativtext des Bildes" input in the mein.berlin interface field at 79 characters, so an over-long value can no longer be entered. The `DpInput` `maxlength` also surfaces the built-in live character counter.

## Changes
- Add `:maxlength="79"` to the pictogram alt text input in `MeinBerlinProcedurePictogram.vue`
- Changelog entry under UNRELEASED

## Testing
- Rebuilt the addon bundle and verified the field hard-caps at 79 characters with the live counter shown