### PR TITLE
Fix beaa2 46 mein berlin orga dropdown preselect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## UNRELEASED
+- **fix**: Pre-select existing mein.berlin organisation ID in org/procedure dropdowns — prevents TypeError crash when API returns `data: null` for relationship items belonging to other customers, which was silently aborting the mounted callback and triggering a create instead of an update
+
 ## v0.31 (2026-06-02)
 - **fix DPLAN-17776**: Limit the procedure pictogram alt text input to 79 characters, since mein.berlin.de rejects alt text of 80 or more characters
 

--- a/client/hooks/InterfaceFieldsToTransmit/MeinBerlinOrgaField.vue
+++ b/client/hooks/InterfaceFieldsToTransmit/MeinBerlinOrgaField.vue
@@ -162,7 +162,7 @@ export default {
 
     getItemByRelationshipId () {
       this.item = Object.values(this.list || []).find(
-        el => el.relationships[this.relationshipKey].data.id === this.relationshipId
+        el => el.relationships?.[this.relationshipKey]?.data?.id === this.relationshipId
       ) || null
 
       // Reset if no item

--- a/client/hooks/InterfaceFieldsToTransmit/MeinBerlinProcedureFields.vue
+++ b/client/hooks/InterfaceFieldsToTransmit/MeinBerlinProcedureFields.vue
@@ -270,7 +270,7 @@ export default {
 
     getItemByRelationshipId () {
       this.item = Object.values(this.list || []).find(
-        el => el.relationships.procedure.data.id === this.relationshipId
+        el => el.relationships?.procedure?.data?.id === this.relationshipId
       ) || null
 
       // Reset if no item


### PR DESCRIPTION
Ticket: https://demoseurope.youtrack.cloud/projects/BEAA2/issues/BEAA2-46

Description: 

The API correctly returns `"data": null` for relationship items belonging to other customers (EDT access conditions). `getItemByRelationshipId()` in `MeinBerlinOrgaField.vue` and `MeinBerlinProcedureFields.vue` accessed `.data.id` without null-guarding, causing a TypeError on the first such item. The error silently aborted the mounted callback, so the stored value was never loaded into the dropdown and any save attempt triggered a CREATE instead of an UPDATE.

Fix: add optional chaining (`?.`) on `relationships[key].data.id`.

### How to review/test

1. Open an organisation that already has a mein.berlin organisation ID stored
2. The dropdown should show the stored value pre-selected (not "Bitte wählen")
3. Select a different value and save → no "relation has to be unique" error